### PR TITLE
disable verbosity by default and proper include

### DIFF
--- a/examples/hecke.c
+++ b/examples/hecke.c
@@ -1,7 +1,7 @@
 
 #include <assert.h>
 #include <stdio.h>
-#include "flint.h"
+#include <flint/flint.h>
 #include "arb.h"
 #include "modular.h"
 

--- a/hilbert/hilbert_linear_combination.c
+++ b/hilbert/hilbert_linear_combination.c
@@ -106,9 +106,9 @@ int hilbert_linear_combination(fmpz* abcde, const acb_mat_t tau, slong delta, sl
   /* Check discriminant */
   fmpz_mul(discr, &abcde[1], &abcde[1]);
   fmpz_mul(temp, &abcde[0], &abcde[2]);
-  fmpz_addmul_si(discr, temp, -4);
+  fmpz_submul_ui(discr, temp, 4);
   fmpz_mul(temp, &abcde[3], &abcde[4]);
-  fmpz_addmul_si(discr, temp, -4);
+  fmpz_submul_ui(discr, temp, 4);
   res = fmpz_equal_si(discr, delta);
 
   if (!res)
@@ -122,14 +122,17 @@ int hilbert_linear_combination(fmpz* abcde, const acb_mat_t tau, slong delta, sl
 	      for (k = 0; k < 5; k++)
 		{
 		  fmpz_mul_si(&abcde[k], fmpz_mat_entry(B, k, 0), l);
-		  fmpz_addmul_si(&abcde[k], fmpz_mat_entry(B, k, 1), m);
+      if (m > 0)
+        fmpz_addmul_ui(&abcde[k], fmpz_mat_entry(B, k, 1), m);
+      else
+        fmpz_submul_ui(&abcde[k], fmpz_mat_entry(B, k, 1), -m);
 		}
 	      /* Check discriminant */
 	      fmpz_mul(discr, &abcde[1], &abcde[1]);
 	      fmpz_mul(temp, &abcde[0], &abcde[2]);
-	      fmpz_addmul_si(discr, temp, -4);
+	      fmpz_submul_ui(discr, temp, 4);
 	      fmpz_mul(temp, &abcde[3], &abcde[4]);
-	      fmpz_addmul_si(discr, temp, -4);
+	      fmpz_submul_ui(discr, temp, 4);
 	      res = fmpz_equal_si(discr, delta);
 	      if (res) break;
 	    }

--- a/hilbert/hilbert_splits.c
+++ b/hilbert/hilbert_splits.c
@@ -46,7 +46,7 @@ int hilbert_splits(fmpz_poly_t beta, slong ell, slong delta)
 	  if (fmpz_is_square(discr))
 	    {
 	      fmpz_sqrt(discr, discr);
-	      fmpz_submul_si(discr, a, 2);
+	      fmpz_submul_ui(discr, a, 2);
 	      if (fmpz_fdiv_ui(discr, delta-1) == 0)
 		{
 		  stop = 1;

--- a/modular.h
+++ b/modular.h
@@ -28,7 +28,11 @@
 #include "siegel.h"
 #include "theta.h"
 
-#define MODEQ_VERBOSE 1
+/* one may want to define verbosity at compile time */
+#ifndef MODEQ_VERBOSE
+#define MODEQ_VERBOSE 0
+#endif
+
 #define MODEQ_RED_TOL_BITS 50
 #define MODEQ_MAX_PREC n_pow(10,6)
 

--- a/modular.h
+++ b/modular.h
@@ -145,7 +145,7 @@ int siegel_modeq_eval_Fp(fmpz_mod_poly_struct* pol_vec,
 			 const fmpz* j, slong ell, const fmpz_mod_ctx_t ctx);
 
 int siegel_modeq_eval_C(acb_poly_struct* num_vec, acb_t den, acb_srcptr j, slong ell,
-			slong prec);			
+			slong prec);
 
 int siegel_modeq_isog_invariants_Q(slong* nb_roots, fmpq* all_isog_j,
 				   fmpq* j, slong ell);

--- a/modular/siegel_modeq_num.c
+++ b/modular/siegel_modeq_num.c
@@ -30,11 +30,11 @@ void siegel_modeq_num(acb_poly_struct* num_vec_acb,
 
       acb_pow_ui(&zi3[k], &I_vec[4*k+1], 5, prec);
     }
-  flint_printf("(siegel_modeq_num) Building product trees...\n");
+  if (MODEQ_VERBOSE) flint_printf("(siegel_modeq_num) Building product trees...\n");
   product_tree_1(&num_vec_acb[0], xi, yi, d, prec);
   product_tree_2(&num_vec_acb[1], xi, yi, zi2, d, prec);
   product_tree_2(&num_vec_acb[2], xi, yi, zi3, d, prec);
-  flint_printf("(siegel_modeq_num) Done.\n");
+  if (MODEQ_VERBOSE) flint_printf("(siegel_modeq_num) Done.\n");
 
   for (k = 0; k < 3; k++)
     {


### PR DESCRIPTION
you can enable verbosity by adding `-DMODEQ_VERBOSE=1` to the Makefile