### PR TITLE
Reverse half weights + typo in igusa/cov_factors.c

### DIFF
--- a/hecke/hecke_all_isog_Q.c
+++ b/hecke/hecke_all_isog_Q.c
@@ -26,7 +26,7 @@ int hecke_all_isog_Q(slong* nb_roots, fmpz* all_I, const hecke_t H, fmpz* I, slo
 
     slong highprec;
     hecke_t H2;
-    slong weights[4] = IGUSA_WEIGHTS;
+    slong weights[4] = IGUSA_HALFWEIGHTS;
 
     highprec = hecke_integral_highprec(H, prec);
     if (v) flint_printf("(hecke_all_isog_Q) Chosen high precision: %wd\n", highprec);

--- a/hilbert/igusa_from_gundlach_fmpz.c
+++ b/hilbert/igusa_from_gundlach_fmpz.c
@@ -4,7 +4,7 @@
 void igusa_from_gundlach_fmpz(fmpz* I, fmpz* G, slong delta)
 {
   fmpz_t temp;
-  slong weights[4] = IGUSA_WEIGHTS;
+  slong weights[4] = IGUSA_HALFWEIGHTS;
   
   fmpz_init(temp);
   

--- a/igusa.h
+++ b/igusa.h
@@ -26,9 +26,9 @@
 #include "verbose.h"
 
 #define IGUSA_WEIGHTS {4,6,10,12}
-// #define IGUSA_HALFWEIGHTS {2,3,5,6}
+#define IGUSA_HALFWEIGHTS {2,3,5,6}
 #define IC_WEIGHTS {2,4,6,10}
-// #define IC_HALFWEIGHTS {1,2,3,5}
+#define IC_HALFWEIGHTS {1,2,3,5}
 /* #define IGUSA_NB 4 would clutter the code. */
 #define X_WEIGHTS {4,6,10,12,12,16,18,24,28,30,36,40,42,48}
 #define X_NB 14

--- a/igusa/cov_factors.c
+++ b/igusa/cov_factors.c
@@ -51,7 +51,7 @@ void cov_factors(fmpz_factor_t fac, fmpz* I, slong nb)
     }
 
   stop = fmpz_factor_smooth(fac, g, COV_FACTOR_BITS, 1);
-  for (k = 0; k < cov_factor_nb(fac); k++) fmpz_remove(g, g, cov_factor_p(fac, k));
+  for (k = 0; k < cov_factor_nb(fac) + (stop ? 0 : -1); k++) fmpz_remove(g, g, cov_factor_p(fac, k));
   if (!stop) cov_factors_additional(fac, g, I, nb);
 
   fmpz_clear(g);

--- a/igusa/igusa_IC_fmpz.c
+++ b/igusa/igusa_IC_fmpz.c
@@ -52,7 +52,7 @@ void igusa_IC_fmpz(fmpz* IC, fmpz* I)
   fmpz* S;
   fmpz* resc;
   slong weights[4] = IGUSA_WEIGHTS;
-  slong weights2[4] = IC_WEIGHTS;
+  slong weights2[4] = IC_HALFWEIGHTS;
   int r;
 
   fmpz_init(I2);

--- a/igusa/igusa_from_IC_fmpz.c
+++ b/igusa/igusa_from_IC_fmpz.c
@@ -29,7 +29,7 @@ igusa_I6prime_from_IC_fmpz(fmpz_t I6prime, fmpz* I)
 void igusa_from_IC_fmpz(fmpz* I, fmpz* IC)
 {
   fmpz_t I6prime, I12;
-  slong weights2[4] = IC_WEIGHTS;
+  slong weights2[4] = IC_HALFWEIGHTS;
   fmpz* resc;
   fmpz* S;
 

--- a/igusa/igusa_from_monomials.c
+++ b/igusa/igusa_from_monomials.c
@@ -11,7 +11,7 @@ void igusa_from_monomials(fmpz* I, fmpz* M, slong wt)
   slong* e6;
   slong* e10;
   slong* e12;
-  slong weights[4] = IGUSA_WEIGHTS;
+  slong weights[4] = IGUSA_HALFWEIGHTS;
   fmpz* res;
 
   fmpz_mpoly_ctx_init(ctx, nb, ORD_LEX);

--- a/igusa/igusa_from_streng_fmpz.c
+++ b/igusa/igusa_from_streng_fmpz.c
@@ -3,7 +3,7 @@
 
 void igusa_from_streng_fmpz(fmpz* I, fmpz* S)
 {
-  slong weights[4] = IGUSA_WEIGHTS;
+  slong weights[4] = IGUSA_HALFWEIGHTS;
   
   cov_rescale_fmpz_si(I, S, 8, 4, weights);  
   fmpz_divexact_si(igusa_psi4(I), &I[0], 4);

--- a/igusa/igusa_streng_fmpz.c
+++ b/igusa/igusa_streng_fmpz.c
@@ -3,7 +3,7 @@
 
 void igusa_streng_fmpz(fmpz* S, fmpz* I)
 {
-  slong weights[4] = IGUSA_WEIGHTS;
+  slong weights[4] = IGUSA_HALFWEIGHTS;
   
   fmpz_mul_si(&S[0], &I[0], 4);
   fmpz_mul_si(&S[1], &I[1], 4);

--- a/igusa/test/t-igusa_IC.c
+++ b/igusa/test/t-igusa_IC.c
@@ -24,6 +24,7 @@ int main()
       fmpq* ABCD;
       fmpq_t R2;
 
+      slong half[4] = IGUSA_HALFWEIGHTS;
       slong weights[4] = IGUSA_WEIGHTS;
       slong weights2[4] = IC_WEIGHTS;
       slong mag_bits = 10;
@@ -43,7 +44,7 @@ int main()
       fmpq_init(R2);
 
       for (k = 0; k < 4; k++) fmpz_randtest_not_zero(&I[k], state, mag_bits);
-      cov_normalize_fmpz(I, I, 4, weights);
+      cov_normalize_fmpz(I, I, 4, half);
       for (k = 0; k < 4; k++) acb_set_fmpz(&I_acb[k], &I[k]);
       acb_randtest_precise(scal, state, prec, mag_bits);
 

--- a/igusa/test/t-igusa_X.c
+++ b/igusa/test/t-igusa_X.c
@@ -24,6 +24,7 @@ int main()
       slong k;
       slong Xweights[X_NB] = X_WEIGHTS;
       slong Iweights[4] = IGUSA_WEIGHTS;
+      slong half[4] = IGUSA_HALFWEIGHTS;
 
       I = _fmpz_vec_init(4);
       X = _fmpq_vec_init(X_NB);
@@ -33,7 +34,7 @@ int main()
 
       for (k = 0; k < 4; k++) fmpz_randtest(&I[k], state, mag_bits);
       fmpz_randtest_not_zero(scal, state, mag_bits);
-      cov_rescale_fmpz_si(I, I, 2*3, 4, Iweights);
+      cov_rescale_fmpz_si(I, I, 2*3, 4, half);
       igusa_X(X, I);
 
       if (print)

--- a/igusa/test/t-igusa_from_monomials.c
+++ b/igusa/test/t-igusa_from_monomials.c
@@ -23,7 +23,7 @@ int main()
       slong wt;
       slong mag_bits = 10;
       slong wts[3] = {20, 30, 60};
-      slong weights[4] = IGUSA_WEIGHTS;
+      slong weights[4] = IGUSA_HALFWEIGHTS;
       int print = 0;
 
       I = _fmpz_vec_init(4);

--- a/igusa/thomae_correct_signs.c
+++ b/igusa/thomae_correct_signs.c
@@ -8,7 +8,7 @@ int thomae_correct_signs(slong* perm, slong* signs, acb_srcptr roots,
   time_pair start; timestamp_mark(&start);
 	// p in {0..719} s in {0..15}
 	slong nb_candidates = 720 * 16;
-	slong weights[4] = IGUSA_WEIGHTS;
+	slong weights[4] = IGUSA_HALFWEIGHTS;
 	slong correct_perm = -1;
 	slong correct_signs = -1;
 	int res = 1;

--- a/igusa/thomae_correct_signs_with_lowprec.c
+++ b/igusa/thomae_correct_signs_with_lowprec.c
@@ -9,7 +9,7 @@ int thomae_correct_signs_with_lowprec(slong* perm, slong* signs, acb_srcptr root
   time_pair start; timestamp_mark(&start);
   slong current_prec = thomae_startprec(prec);
   slong nb_candidates = 720 * 16;
-  slong weights[4] = IGUSA_WEIGHTS;
+  slong weights[4] = IGUSA_HALFWEIGHTS;
   slong th2weights[16] = {1,1,1,1,    1,1,1,1,
     1,1,1,1,    1,1,1,1};
   slong p; /* 0 to 719 */

--- a/igusa/thomae_keep_candidate.c
+++ b/igusa/thomae_keep_candidate.c
@@ -4,7 +4,7 @@
 int thomae_keep_candidate(const acb_mat_t tau, acb_srcptr I, slong prec)
 {
   acb_ptr test;
-  slong weights[4] = IGUSA_WEIGHTS;
+  slong weights[4] = IGUSA_HALFWEIGHTS;
   int aux, res;
 
   test = _acb_vec_init(4);

--- a/modular/modeq_ctx_choose.c
+++ b/modular/modeq_ctx_choose.c
@@ -6,7 +6,7 @@ int modeq_ctx_choose(modeq_ctx_t ctx, acb_srcptr I, slong nb, slong prec)
   slong j, k, l;
   slong j0 = -1;
   acb_srcptr ptr; /* Do not initialize */
-  slong weights[4] = IGUSA_WEIGHTS;
+  slong weights[4] = IGUSA_HALFWEIGHTS;
   slong exps[4];
   fmpz_mpoly_t num, den;
   acb_ptr evden;

--- a/modular/test/t-siegel_2step_direct_isog_Q.c
+++ b/modular/test/t-siegel_2step_direct_isog_Q.c
@@ -106,10 +106,10 @@ https://beta.lmfdb.org/Genus2Curve/Q/295/a/295/2 */
 				fmpz_set_si(&I1[2], 20835);
 				fmpz_set_si(&I1[3], 37760);
 				ell = 7;
-				fmpz_set_si(&I2[0], -198804);
+				fmpz_set_si(&I2[0], 198804);
 				fmpz_set_si(&I2[1], 305807001);
-				fmpz_set_si(&I2[2], -18482629056189);
-				fmpz_set_si(&I2[3], 37760);
+				fmpz_set_si(&I2[2], 18482629056189);
+				fmpz_set_si(&I2[3], -37760);
 				break;
 
 
@@ -140,14 +140,6 @@ https://beta.lmfdb.org/Genus2Curve/Q/295/a/295/2 */
 		if (!res)
 		{
 			flint_printf("FAIL (values)\n");
-			flint_printf("nb_roots = %wd\n", nb_roots);
-			_fmpz_vec_print(I2, 4);
-			flint_printf("\n");
-			for (k = 0; k < nb_roots; k++)
-			{
-				_fmpz_vec_print(&all_I[4*k], 4);
-				flint_printf("\n");
-			}
 			fflush(stdout);
 			flint_abort();
 		}


### PR DESCRIPTION
I reversed the half weights change and fixed an issue in`igusa/cov_factors.c`

e.g.
```
sage: modular_igusa_from_igusa_clebsch([2^9 * 3 * 5^2 * 23 * 59^2 * 113 * 137^2 * 307^2 * 683^2 * 829^2 * 5791^2 * 40153 * 2787409^2 * 191780593^2,
....:  2^14 * 3^6 * 5^4 * 59^8 * 137^4 * 307^4 * 683^4 * 829^4 * 5791^4 * 2787409^5 * 191780593^4,
....:  2^21 * 3^6 * 5^6 * 59^10 * 137^6 * 307^6 * 331 * 683^6 * 829^6 * 5107 * 5791^6 * 9137 * 75989 * 2787409^6 * 191780593^6,
....:  -1 * 2^47 * 3^9 * 5^10 * 7^2 * 31^2 * 59^22 * 61 * 137^10 * 307^10 * 683^10 * 829^10 * 5791^10 * 2787409^10 * 191780593^10])
Exception (fmpz_remove). factor f <= 1.
....
```
with the fix
```
sage: modular_igusa_from_igusa_clebsch([2^9 * 3 * 5^2 * 23 * 59^2 * 113 * 137^2 * 307^2 * 683^2 * 829^2 * 5791^2 * 40153 * 2787409^2 * 191780593^2,
....:  2^14 * 3^6 * 5^4 * 59^8 * 137^4 * 307^4 * 683^4 * 829^4 * 5791^4 * 2787409^5 * 191780593^4,
....:  2^21 * 3^6 * 5^6 * 59^10 * 137^6 * 307^6 * 331 * 683^6 * 829^6 * 5107 * 5791^6 * 9137 * 75989 * 2787409^6 * 191780593^6,
....:  -1 * 2^47 * 3^9 * 5^10 * 7^2 * 31^2 * 59^22 * 61 * 137^10 * 307^10 * 683^10 * 829^10 * 5791^10 * 2787409^10 * 191780593^10])
(225780129, 235627701489, -25917214504608, -776977742744947296)
```
as 191780593 > 2^25